### PR TITLE
Add workflow to build images weekly

### DIFF
--- a/.env
+++ b/.env
@@ -19,7 +19,7 @@
 # for the parameters in docker-compose.yml.
 
 # Default repository to pull and push images from
-REPO=apache/arrow-dev
+REPO=ghcr.io/apache/arrow-nanoarrow
 
 # Linux platform (i.e., the dockerfile to use from ci/docker)
 PLATFORM=ubuntu

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -31,8 +31,6 @@ jobs:
   build-docker:
     name: "docker-${{ matrix.config.platform }}-${{ matrix.config.docker_platform }}"
     runs-on: ubuntu-latest
-    env:
-      REPO: "ghcr.io/assignuser/arrow-nanoarrow"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -30,7 +30,7 @@ jobs:
     name: "docker-${{ matrix.config.platform }}-${{ matrix.config.docker_platform }}"
     runs-on: ubuntu-latest
     env:
-      REPO: "ghcr.io/${{github.repository}}"
+      REPO: "ghcr.io/assignuser/arrow-nanoarrow"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,0 +1,67 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+name: Build Docker Images
+
+on:
+  workflow_dispatch:
+  push:
+
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-docker:
+    name: "docker-${{ matrix.config.platform }}-${{ matrix.config.docker_platform }}"
+    runs-on: ubuntu-latest
+    env:
+      REPO: "ghcr.io/${{github.repository}}"
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - { platform: "ubuntu", docker_platform: "amd64" }
+          - { platform: "fedora", docker_platform: "amd64" }
+          - { platform: "archlinux", docker_platform: "amd64" }
+          - { platform: "alpine", docker_platform: "amd64" }
+          - { platform: "alpine", docker_platform: "s390x" }
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        if: matrix.config.docker_platform != 'amd64'
+        uses: docker/setup-qemu-action@v2
+
+      - name: Build and Push
+        env:
+          PLATFORM: ${{ matrix.config.platform }}
+          DOCKER_DEFAULT_PLATFORM: "linux/${{ matrix.config.docker_platform }}"
+        run: |
+          docker compose build
+          docker compose push

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -47,6 +47,9 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -18,8 +18,10 @@ name: Build Docker Images
 
 on:
   workflow_dispatch:
-  push:
-
+  schedule:
+    - cron: '5 0 * * 1'
+  pull_request:
+    paths: = 'ci/docker/*' - '.github/workflow/docker-build.yaml' = 'docker-compose.yaml'
 
 permissions:
   contents: read
@@ -61,10 +63,17 @@ jobs:
         if: matrix.config.docker_platform != 'amd64'
         uses: docker/setup-qemu-action@v2
 
-      - name: Build and Push
+      - name: Build
         env:
           PLATFORM: ${{ matrix.config.platform }}
           DOCKER_DEFAULT_PLATFORM: "linux/${{ matrix.config.docker_platform }}"
         run: |
           docker compose build
+
+      - name: Push
+        if: ${{ github.event_name != 'pull_request' && github.repository == 'apache/arrow-nanoarrow'}}
+        env:
+          PLATFORM: ${{ matrix.config.platform }}
+          DOCKER_DEFAULT_PLATFORM: "linux/${{ matrix.config.docker_platform }}"
+        run: |
           docker compose push

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,9 +25,9 @@ services:
       context: .
       cache_from:
         - ${REPO}:nanoarrow-${PLATFORM}
+      cache_to:
+        - ${REPO}:nanoarrow-${PLATFORM}
       dockerfile: ci/docker/${PLATFORM}.dockerfile
-      args:
-        PLATFORM: ${PLATFORM}
     volumes:
       - .:/nanoarrow
     command: "/bin/bash /nanoarrow/dev/release/verify-release-candidate.sh"


### PR DESCRIPTION
The workflow builds and pushes the images, it will also run on PRs when relevant (no push there ofc).

You can see the images on my fork: https://github.com/assignUser/arrow-nanoarrow/pkgs/container/arrow-nanoarrow
They will show up on the sidebar of the repo too 
![image](https://user-images.githubusercontent.com/16141871/225518222-aa5122c6-a8dc-4581-b620-3ba5233f0471.png)
